### PR TITLE
simplify encoding detection

### DIFF
--- a/cached_url/__init__.py
+++ b/cached_url/__init__.py
@@ -24,15 +24,8 @@ def getUrlContent(url, headers={}, mode='', sleep=0):
         accept_list = ['text', 'html', 'xml', 'json']
         if r.headers.get('content-type') and any(accept in r.headers['content-type'] for accept in accept_list):  # is webpage
             r.iter_content()
-
-            if r.encoding == 'ISO-8859-1':  # no encoding is set on the page
-                encodings = requests.utils.get_encodings_from_content(r.text)  # guess encoding from content
-                if encodings:  # guess encoding out
-                    r.encoding = encodings[0]
-                else:  # guess encoding failed
-                    r.encoding = r.apparent_encoding  # use r.headers['content-encoding']
-            print(r.encoding)
-
+            if r.encoding == 'ISO-8859-1':  # requests use default ISO-8859-1 while encoding is not set
+                r.encoding = None  # set encoding to None so Response.text() will detect the encoding
             return r.text
 
         raise Exception('Not a webpage: ' + url)


### PR DESCRIPTION
`Response.text()` contains encoding detection, just activate it with setting `Response.encoding` to `None` while it is default `ISO-8859-1`